### PR TITLE
Fix anchor constraints by drawing a constraints for every label anchor.

### DIFF
--- a/src/placement/constraint_updater.cpp
+++ b/src/placement/constraint_updater.cpp
@@ -208,11 +208,13 @@ void ConstraintUpdater::drawConnectorShadowRegion(
   positions.clear();
 }
 
-void ConstraintUpdater::drawAnchorRegion(Eigen::Vector2i anchorPosition,
-                                         Eigen::Vector2i labelSize)
+void ConstraintUpdater::drawRegionsForAnchors(
+    std::vector<Eigen::Vector2i> anchorPositions, Eigen::Vector2i labelSize)
 {
   positions.clear();
-  drawPolygon(createBoxPolygon(anchorPosition, 2 * labelSize));
+  for (auto &anchorPosition : anchorPositions)
+    drawPolygon(createBoxPolygon(anchorPosition, 2 * labelSize));
+
   drawer->drawElementVector(positions, anchorConstraintColor);
 }
 

--- a/src/placement/constraint_updater.h
+++ b/src/placement/constraint_updater.h
@@ -39,8 +39,8 @@ class ConstraintUpdater
                                Eigen::Vector2i lastAnchorPosition,
                                Eigen::Vector2i lastLabelPosition,
                                Eigen::Vector2i lastLabelSize);
-  void drawAnchorRegion(Eigen::Vector2i anchorPosition,
-                        Eigen::Vector2i labelSize);
+  void drawRegionsForAnchors(std::vector<Eigen::Vector2i> anchorPositions,
+                             Eigen::Vector2i labelSize);
 
   void clear();
   void setIsConnectorShadowEnabled(bool enabled);

--- a/src/placement/labeller.cpp
+++ b/src/placement/labeller.cpp
@@ -68,13 +68,13 @@ Labeller::update(const LabellerFrameData &frameData)
   costSum = 0.0f;
   auto labelsInLayer = labelsArranger->getArrangement(frameData, labels);
 
-  std::map<int, Eigen::Vector2i> anchorPositionsForBuffer;
+  std::vector<Eigen::Vector2i> anchorPositionsForBuffer;
   for (auto &label : labelsInLayer)
   {
     auto anchor2D = frameData.project(label.anchorPosition);
     Eigen::Vector2i anchorForBuffer = toPixel(anchor2D, bufferSize).cast<int>();
 
-    anchorPositionsForBuffer[label.id] = anchorForBuffer;
+    anchorPositionsForBuffer.push_back(anchorForBuffer);
   }
 
   constraintUpdater->setAnchorPositions(anchorPositionsForBuffer);

--- a/src/placement/persistent_constraint_updater.cpp
+++ b/src/placement/persistent_constraint_updater.cpp
@@ -1,6 +1,7 @@
 #include "./persistent_constraint_updater.h"
 #include <QLoggingCategory>
 #include <chrono>
+#include <vector>
 #include "./constraint_updater.h"
 
 QLoggingCategory pcuChan("Placement.PersistentConstraintUpdater");
@@ -12,7 +13,7 @@ PersistentConstraintUpdater::PersistentConstraintUpdater(
 }
 
 void PersistentConstraintUpdater::setAnchorPositions(
-    std::map<int, Eigen::Vector2i> anchorPositions)
+    std::vector<Eigen::Vector2i> anchorPositions)
 {
   this->anchorPositions = anchorPositions;
 }
@@ -24,9 +25,7 @@ void PersistentConstraintUpdater::updateConstraints(
   auto startTime = std::chrono::high_resolution_clock::now();
   constraintUpdater->clear();
 
-  for (auto &anchorPosition : anchorPositions)
-    constraintUpdater->drawAnchorRegion(anchorPosition.second,
-                                        labelSizeForBuffer);
+  constraintUpdater->drawRegionsForAnchors(anchorPositions, labelSizeForBuffer);
 
   for (auto &placedLabelPair : placedLabels)
   {

--- a/src/placement/persistent_constraint_updater.h
+++ b/src/placement/persistent_constraint_updater.h
@@ -5,6 +5,7 @@
 #include <Eigen/Core>
 #include <memory>
 #include <map>
+#include <vector>
 
 class ConstraintUpdater;
 
@@ -24,7 +25,7 @@ class PersistentConstraintUpdater
   PersistentConstraintUpdater(
       std::shared_ptr<ConstraintUpdater> constraintUpdater);
 
-  void setAnchorPositions(std::map<int, Eigen::Vector2i> anchorPositions);
+  void setAnchorPositions(std::vector<Eigen::Vector2i> anchorPositions);
   void updateConstraints(int labelId, Eigen::Vector2i anchorForBuffer,
                          Eigen::Vector2i labelSizeForBuffer);
   void setPosition(int labelId, Eigen::Vector2i position);
@@ -41,7 +42,7 @@ class PersistentConstraintUpdater
   std::shared_ptr<ConstraintUpdater> constraintUpdater;
 
   std::map<int, PlacedLabelInfo> placedLabels;
-  std::map<int, Eigen::Vector2i> anchorPositions;
+  std::vector<Eigen::Vector2i> anchorPositions;
 };
 
 #endif  // SRC_PLACEMENT_PERSISTENT_CONSTRAINT_UPDATER_H_

--- a/test/placement/test_constraint_updater.cc
+++ b/test/placement/test_constraint_updater.cc
@@ -29,7 +29,8 @@ class Test_ConstraintUpdater : public ::testing::Test
     Eigen::Vector2i lastAnchorPosition(200, 70);
     Eigen::Vector2i lastLabelPosition(150, 120);
     Eigen::Vector2i lastLabelSize(60, 40);
-    constraintUpdater->drawAnchorRegion(anchorPosition, labelSize);
+    std::vector<Eigen::Vector2i> anchorPositions = { anchorPosition };
+    constraintUpdater->drawRegionsForAnchors(anchorPositions, labelSize);
     constraintUpdater->drawConstraintRegionFor(
         anchorPosition, labelSize, lastAnchorPosition, lastLabelPosition,
         lastLabelSize);


### PR DESCRIPTION
Previously only anchors of already placed labels were drawn.
